### PR TITLE
Make system collections analyzing optional

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,9 @@ const optionDefinitions = [
   {
     name: 'dont-follow-fk', alias: 'n', multiple: true, type: String,
   },
+  {
+    name: 'include-system', alias: 's', type: Boolean, defaultValue: false,
+  },
 ];
 
 const args = commandLineArgs(optionDefinitions);
@@ -39,6 +42,7 @@ const printUsage = function () {
   console.log('\t\t-r, --raw\tShows the exact list of types with frequency instead of the most frequent type only.');
   console.log('\t\t-l, --limit\tChanges the amount of items to parse from the collections. Default is 100.');
   console.log("\t\t-n, --dont-follow-fk string\tDon't follow specified foreign key. Can be simply \"fieldName\" (all collections) or \"collectionName:fieldName\" (only for given collection).");
+  console.log("\t\t-n, --include-system string\tAnalyzes system collections as well.");
   console.log('');
   console.log('Enjoy! :)');
   console.log('');
@@ -110,6 +114,7 @@ const opts = {
   raw: args.raw,
   limit: args.limit,
   dontFollowFK,
+  includeSystem: args['include-system'],
 };
 
 (async () => {

--- a/extract-mongo-schema.js
+++ b/extract-mongo-schema.js
@@ -190,6 +190,14 @@ const getSchema = async (url, opts) => {
     }
   }
 
+  if (!opts.includeSystem) {
+    for (let i = collectionInfos.length - 1; i >= 0; i--) {
+      if (collectionInfos[i].name.startsWith('system.')) {
+        collectionInfos.splice(i, 1);
+      }
+    }
+  }
+
   await Promise.all(collectionInfos.map(async (collectionInfo, index) => {
     collections[collectionInfo.name] = {};
     schema[collectionInfo.name] = {};


### PR DESCRIPTION
When you try to scan the "admin" DB, `.listCollections()` will return some system collections that are internal to MongoDB, and that even users with admin rights can't access. We can recognize them because their names start with `system.` (system.keys, system.version, and a few others). 

The script fails when trying to scan those:  `MongoError: not authorized on admin to execute command { find: "system.keys ... }`. That's because those collections are not supposed to be accessed, even by admin users ; see more info here: https://docs.mongodb.com/manual/reference/system-collections/ 

I suggest those collections are skipped by default. If one really wants to analyze them for some reason, they can use the new CLI option `--include-system`. 

